### PR TITLE
112. Path Sum - Python

### DIFF
--- a/PYTHON/112_Path_Sum.py
+++ b/PYTHON/112_Path_Sum.py
@@ -1,0 +1,10 @@
+class Solution:
+    def hasPathSum(self, root: Optional[TreeNode], targetSum: int) -> bool:
+        def dfs(node,cursum):
+            if not node:
+                return False
+            cursum += node.val
+            if not node.left and not node.right:
+                return cursum==targetSum
+            return dfs(node.left,cursum) or dfs(node.right,cursum)
+        return dfs(root,0)


### PR DESCRIPTION
Given the root of a binary tree and an integer targetSum, return true if the tree has a root-to-leaf path such that adding up all the values along the path equals targetSum.

A leaf is a node with no children.

Example1:
![image](https://user-images.githubusercontent.com/91279248/197258372-059f2242-e32b-4c77-a082-df473cf5434d.png)
![image](https://user-images.githubusercontent.com/91279248/197258410-125e08df-3d07-43f6-8d02-5fa03a53ee86.png)

Constraints:
![image](https://user-images.githubusercontent.com/91279248/197258488-1093d486-08a2-4bcf-9ee4-1ae4a5cbed25.png)