### PR TITLE
56. Merge Intervals - Python

### DIFF
--- a/PYTHON/56_Merge_Intervals.py
+++ b/PYTHON/56_Merge_Intervals.py
@@ -1,0 +1,13 @@
+class Solution:
+    def merge(self, intervals: List[List[int]]) -> List[List[int]]:
+        intervals.sort(key=lambda x:x[0])
+        i=1
+        while i<len(intervals):
+            if intervals[i][0]<=intervals[i-1][1]:
+                intervals[i-1][0]=min(intervals[i-1][0],intervals[i][0])
+                intervals[i-1][1]=max(intervals[i-1][1],intervals[i][1])
+                intervals.pop(i)
+                # i+=1
+            else:
+                i=i+1
+        return intervals


### PR DESCRIPTION
Given an array of intervals where intervals[i] = [starti, endi], merge all overlapping intervals, and return an array of the non-overlapping intervals that cover all the intervals in the input.

Examples:
![image](https://user-images.githubusercontent.com/91279248/197267585-47a08e76-445c-48e8-b7b2-31f301865e99.png)

Constraints:
![image](https://user-images.githubusercontent.com/91279248/197267658-3a04a5f7-dd4f-4a5e-b45a-9e0335856693.png)
